### PR TITLE
Allow using the redirectUri to start the login process.

### DIFF
--- a/parse-facebook-user-session.js
+++ b/parse-facebook-user-session.js
@@ -174,12 +174,15 @@ var parseFacebookUserSession = function(params) {
       return next();
     }
 
-    // If this is the Facebook login redirect URL, then handle the code.
+    // If this is the Facebook login redirect URL, and a code is present, then handle the code.
+    // If a code is not present, begin the login process.
     var absoluteRedirectUri = 'https://' + req.host + relativeRedirectUri;
     if (req.path === relativeRedirectUri) {
-      endLogin(req, res);
-    } else {
-      beginLogin(req, res);
+      if (req.query.code) {
+        endLogin(req, res);
+      } else {
+        beginLogin(req, res);
+      }
     }
   };
 };


### PR DESCRIPTION
Suggested by Benjamin Wasser, this update would allow developers to just use 1 route for triggering and processing the login with Facebook.  Requiring the code here makes sense, as the login cannot succeed without it.
