### PR TITLE
Saving a user's email address

### DIFF
--- a/parse-facebook-user-session.js
+++ b/parse-facebook-user-session.js
@@ -139,6 +139,7 @@ var parseFacebookUserSession = function(params) {
     }).then(function(user) {
       maybeLog("Saving Facebook data for user...");
       user.set("name", facebookData.name);
+      user.set("email", facebookData.email);
       return user.save();
 
     }).then(function(user) {


### PR DESCRIPTION
Saving a user's email address in Parse user DB can be quite useful for a number of reasons. Adding this extra line of code to do so.
