### PR TITLE
Fix typo in call to Parse.User.become(response.sessionToken)

### DIFF
--- a/parse-facebook-user-session.js
+++ b/parse-facebook-user-session.js
@@ -134,7 +134,7 @@ var parseFacebookUserSession = function(params) {
 
     }).then(function(response) {
       maybeLog("Becoming Parse user...");
-      return Parse.User.become(response.sessionToken);
+      return Parse.User.become(response.getSessionToken());
 
     }).then(function(user) {
       maybeLog("Saving Facebook data for user...");


### PR DESCRIPTION
The existing code tries to become the user for the session token `response.sessionToken` but this will always be `undefined` since `sessionToken` isn't a property of `ParseUser`. Calling `response.getSessionToken()` gets the correct session token.

The reason this didn't manifest before is that the code later in the middleware works regardless of whether we become the user or not.