### PR TITLE
Add user data permissions specifying in prameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ as described in
     var parseExpressHttpsRedirect = require('parse-express-https-redirect');
     var parseExpressCookieSession = require('parse-express-cookie-session');
     var parseFacebookUserSession = require('cloud/parse-facebook-user-session');
-    
+
     // ... Configure the express app ...
-    
+
     app.use(parseExpressHttpsRedirect());  // Require user to be on HTTPS.
     app.use(express.bodyParser());
     app.use(express.cookieParser('YOUR_SIGNING_SECRET'));
@@ -34,6 +34,7 @@ on every page, use the `app.use` express method.</p>
       clientId: 'YOUR_FB_CLIENT_ID',
       appSecret: 'YOUR_FB_APP_SECRET',
       redirectUri: '/login',
+      scope: 'user_friends',
     }));
 
 If you'd like to only require Facebook Login on certain pages, you can include
@@ -43,6 +44,7 @@ the middleware in your routing commands.
       clientId: 'YOUR_FB_CLIENT_ID',
       appSecret: 'YOUR_FB_APP_SECRET',
       redirectUri: '/login',
+      scope: 'user_friends',
     }));
 
     // To handle the login redirect.
@@ -56,7 +58,7 @@ You can access the user on any page with `Parse.User.current`.
 
     app.get('/', function(req, res) {
       var user = Parse.User.current();
-    
+
       res.render('hello', {
         message: 'Congrats, you are logged in, ' + user.get('username') + '!'
       });

--- a/parse-facebook-user-session.js
+++ b/parse-facebook-user-session.js
@@ -13,6 +13,7 @@ var querystring = require('querystring');
  * <p>Params includes the following:<pre>
  *   clientId    (required): The client id of the Facebook App.
  *   appSecret   (required): The app secret of the Facebook App.
+ *   scope       (optional): What type of access you need. A comma separated list of scopes.
  *   verbose     (optional): If true, output debug messages to console.log.
  *   redirectUri (optional): The path on this server to use for handling the
  *       redirect callback from Facebook. If this is omitted, it defaults to
@@ -70,7 +71,8 @@ var parseFacebookUserSession = function(params) {
       url = url + querystring.stringify({
         client_id: params.clientId,
         redirect_uri: getAbsoluteRedirectUri(req),
-        state: request.id
+        state: request.id,
+        scope: params.scope
       });
       res.redirect(302, url);
 
@@ -124,7 +126,7 @@ var parseFacebookUserSession = function(params) {
       facebookData = response.data;
       var expiration = moment().add('seconds', expires).format(
           "YYYY-MM-DDTHH:mm:ss.SSS\\Z");
-      
+
       return Parse.FacebookUtils.logIn({
         id: response.data.id,
         access_token: accessToken,


### PR DESCRIPTION
Add scope so when calling `parseFacebookUserSession` function. Users can decide what permissions are needed quickly.

	app.use(parseFacebookUserSession({
	  clientId: 'YOUR_FB_CLIENT_ID',
	  appSecret: 'YOUR_FB_APP_SECRET',
	  redirectUri: '/login',
	  scope: 'user_friends,user_likes',
	}));